### PR TITLE
Assume binary file type for .ntkc and .sym files

### DIFF
--- a/toolbox/os.cpp
+++ b/toolbox/os.cpp
@@ -269,6 +269,9 @@ namespace OS
 				// MrC / MrCpp temp file.
 				if (ext == "n")
 					return true;
+				// Newton C++ Tootls output
+				if (ext == "ntkc")
+					return true;				
 				break;
 
 			case 'o':
@@ -276,7 +279,12 @@ namespace OS
 					return true;
 				if (ext == "obj")
 					return true;
+				break;
 
+			case 's':
+				// Newton C++ Intermediate file
+				if (ext == "sym")
+					return true;				
 				break;
 		}
 

--- a/toolbox/os.cpp
+++ b/toolbox/os.cpp
@@ -269,7 +269,7 @@ namespace OS
 				// MrC / MrCpp temp file.
 				if (ext == "n")
 					return true;
-				// Newton C++ Tootls output
+				// Newton C++ Tools output
 				if (ext == "ntkc")
 					return true;				
 				break;


### PR DESCRIPTION
mpw works great for compiling ARM code for the Apple Newton.  However, a few of the tools are not very good at setting the binary flag.   As such, some files have their 0x0D's swapped out for 0x0A's-- not very good for binary files.

This patch just adds two file types used by the Newton C++ Toolkit to the list of files that are assumed to be binary.