### PR TITLE
Add step to initialize and fetch submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ is in the public domain.
 
 ## Building
 
+First initialize and fetch submodules:
+
+    git submodule init
+    git submodule update
+
 Compiling requires cmake, ragel, lemon, and a recent version of clang++ with 
 c++11 support.  It has only been built and tested with OS X 10.8+.
 


### PR DESCRIPTION
I was getting this error:

```
CMake Error at CMakeLists.txt:28 (add_subdirectory):
  add_subdirectory given source "libsane" which is not an existing directory.
```

because I didn't know that I had to initialize `libsane` that is a git submodule.

https://www.git-scm.com/book/en/v2/Git-Tools-Submodules