### PR TITLE
Add newline after read() debug output

### DIFF
--- a/mpw/mpw_io.cpp
+++ b/mpw/mpw_io.cpp
@@ -74,7 +74,7 @@ namespace MPW
 		int fd = f.cookie;
 		ssize_t size;
 
-		Log("     read(%04x, %08x, %08x)", fd, f.buffer, f.count);
+		Log("     read(%04x, %08x, %08x)\n", fd, f.buffer, f.count);
 		size = OS::Internal::FDEntry::read(fd, memoryPointer(f.buffer), f.count);
 		//Log(" -> %ld\n", size);
 

--- a/toolbox/dispatch.cpp
+++ b/toolbox/dispatch.cpp
@@ -505,7 +505,7 @@ namespace ToolBox {
 				 */
 
 				Push<4>(returnPC == 0 ? cpuGetPC() : returnPC);
-				Log("$04x *%s - $%08x", trap, TrapName(trap), address);
+				Log("$04x *%s - $%08x\n", trap, TrapName(trap), address);
 				cpuInitializeFromNewPC(address);
 				return;
 			}


### PR DESCRIPTION
This adds a newline after the debug output for the `read()` function when `--trace-mpw` is enabled (and also for a commented-out debug line in `toolbox::dispatch()`).

This prevents debugging lines that run together, like:

```
f003 Read(00e7a450)
     read(0007, 00818034, 00001000)f005 IOCtl(00e7a43c, 00006603, 00fffc2c)
     bufsize(06)
```

Alternately, uncomment the subsequent `//Log(" -> %ld\n", size);` line since it includes the newline already.