### PR TITLE
Use /bin/sh; quote shell variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ or create a shell script (in `/usr/local/bin`, etc)
 
     #!/bin/sh
     
-    exec mpw AsmIIgs $@
+    exec mpw AsmIIgs "$@"
 
 
 mpw uses the MPW `$Commands` variable to find the command, similar to `$PATH` on Unix.  If the `$Commands` variable

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ or create a shell script (in `/usr/local/bin`, etc)
 
 `/usr/local/bin/AsmIIgs`:
 
-    #!/usr/bin/sh
+    #!/bin/sh
     
     exec mpw AsmIIgs $@
 

--- a/README.text
+++ b/README.text
@@ -86,7 +86,7 @@ or create a shell script (in /usr/local/bin, etc)
 
 #!/bin/sh
 
-exec mpw AsmIIgs $@
+exec mpw AsmIIgs "$@"
 
 mpw looks in the current directory and then in the $MPW:Tools: directory
 for the command to run.  The MPW $Commands variable is not yet supported.

--- a/README.text
+++ b/README.text
@@ -84,7 +84,7 @@ or create a shell script (in /usr/local/bin, etc)
 
 /usr/local/bin/AsmIIgs:
 
-#!/usr/bin/sh
+#!/bin/sh
 
 exec mpw AsmIIgs $@
 

--- a/verbatim/makefile.sh
+++ b/verbatim/makefile.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 infile="$1"
 


### PR DESCRIPTION
The readme says mpw emulator requires OS X 10.8+. On macOS, the `sh` executable is at /bin/sh, not /usr/bin/sh; fix all references to it.

Also, quote `$@` properly in the sample shell wrapper scripts. Quoting `$@` is necessary so that arguments that contain spaces are handled properly.