### PR TITLE
Don't overwrite user-specified CFLAGS and CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,12 @@ set(CMAKE_C_STANDARD_REQUIRED TRUE)
 set(CMAKE_C_EXTENSIONS FALSE)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        # Clang or AppleClang
+        set(CMAKE_CXX_FLAGS "-Wall")
+endif()
+
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
 	# Clang or AppleClang
-	set(CMAKE_CXX_FLAGS "-Wall")
 	set(CMAKE_C_FLAGS "-Wall")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ set(CMAKE_C_EXTENSIONS FALSE)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         # Clang or AppleClang
-        set(CMAKE_CXX_FLAGS "-Wall")
+        set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
 endif()
 
 if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
 	# Clang or AppleClang
-	set(CMAKE_C_FLAGS "-Wall")
+	set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
 endif()
 
 


### PR DESCRIPTION
While investigating a compile problem I noticed that your build was ignoring the CFLAGS and CXXFLAGS I had specified and using only its own (`-Wall`). This fixes it by prepending `-Wall` to the user flags rather than overwriting them. This allows the user to override your flags at the command line if they want to.

I also separated the C and C++ compiler checks. You were only checking if the C++ compiler is clang and using that result to decide what to do for both the C and C++ compiler. Now each is checked and handled individually.