### PR TITLE
Fix compilation with current readline

### DIFF
--- a/bin/debugger.cpp
+++ b/bin/debugger.cpp
@@ -43,6 +43,7 @@
 #include <bitset>
 
 #include <readline/readline.h>
+#include <readline/history.h>
 
 
 #include "loader.h"
@@ -1225,7 +1226,7 @@ namespace {
 	{
 		rl_readline_name = (char *)"mpw";
 		rl_attempted_completion_function = mpw_attempted_completion_function;
-		rl_completion_entry_function = (Function *)mpw_completion_entry_function;
+		rl_completion_entry_function = (rl_compentry_func_t *)mpw_completion_entry_function;
 	}
 }
 


### PR DESCRIPTION
This PR fixes the following errors I got when trying to compile the latest code on macOS 12.3.1 with readline 8.1.2.000 installed (using MacPorts):

```
[ 73%] Building CXX object bin/CMakeFiles/mpw.dir/debugger.cpp.o
cd /path/to/build/bin && /usr/bin/clang++  -I/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1 -I/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin -I/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/libsane/include -Wall -Wno-deprecated-declarations -Wno-unused-variable -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -mmacosx-version-min=12.0 -std=c++11 -MD -MT bin/CMakeFiles/mpw.dir/debugger.cpp.o -MF CMakeFiles/mpw.dir/debugger.cpp.o.d -o CMakeFiles/mpw.dir/debugger.cpp.o -c /path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin/debugger.cpp
/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin/debugger.cpp:1228:34: error: incompatible function pointer types assigning to 'rl_compentry_func_t *' (aka 'char *(*)(const char *, int)') from 'Function *' (aka 'int (*)()')
                rl_completion_entry_function = (Function *)mpw_completion_entry_function;
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin/debugger.cpp:1240:2: error: use of undeclared identifier 'add_history'
        add_history("!Andy, it still has history!");
        ^
/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin/debugger.cpp:1312:4: error: unknown type name 'HIST_ENTRY'
                        HIST_ENTRY *he = current_history();
                        ^
/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin/debugger.cpp:1312:21: error: use of undeclared identifier 'current_history'
                        HIST_ENTRY *he = current_history();
                                         ^
/path/to/mpw-022d4cffe99e2a0f991182196491cba434e842a1/bin/debugger.cpp:1314:5: error: use of undeclared identifier 'add_history'
                                add_history(cp);
                                ^
5 errors generated.
make[2]: *** [bin/CMakeFiles/mpw.dir/debugger.cpp.o] Error 1
```

`Function *` is an ancient readline type which no longer exists. `Function *` and friends were [deprecated in readline 4.2](https://lists.gnu.org/archive/html/info-gnu/2001-04/msg00006.html) (released April 2001) and removed in readline 6.3 (released February 2014).

The `add_history` and `current_history` functions and the `HIST_ENTRY` type appear to be defined in `<readline/history.h>` which I guess needs to be included separately now.