### PR TITLE
Remove macOS 10.15 runner; add macOS 12 runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11.0, macos-10.15]
+        os: [macos-12, macos-11]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The macOS 10.15 runner is deprecated and will be unsupported by December 1.

See https://github.com/actions/runner-images/issues/5583