### PR TITLE
Add error message when loader can't load command

### DIFF
--- a/bin/loader.cpp
+++ b/bin/loader.cpp
@@ -957,10 +957,19 @@ int main(int argc, char **argv)
 
 #ifdef LOADER_LOAD
 	uint16_t err = Loader::Native::LoadFile(command);
-	if (err) exit(EX_CONFIG);
+	if (err) {
+		const char *cp = ErrorName(err);
+		fprintf(stderr, "Unable to load command %s: ", command.c_str());
+		if (cp) printf("%s\n", cp);
+		else printf("%hd\n", err);
+		exit(EX_SOFTWARE);
+	}
 #else
 	uint32_t address = load(command.c_str());
-	if (!address) exit(EX_CONFIG);
+	if (!address) {
+		fprintf(stderr, "Unable to load command %s\n", command.c_str());
+		exit(EX_SOFTWARE);
+	}
 #endif
 	GlobalInit();
 


### PR DESCRIPTION
I was trying to use the CodeWarrior MWC68K and MWCPPC compilers with the mpw emulator and I got no error message and only exit code 78, which was confusing:

```sh
% mpw MWC68K; echo $?
78
% mpw MWCPPC; echo $?
78
%
```

It took me some time to realize that the method I had used to transfer the MWC68K and MWCPPC tools from my Power Mac had not preserved the resource fork which of course made the tools unusable.

Exit code 78 is `EX_CONFIG` and there are several places in the code that use this exit code but most of them first print error messages and are about actual configuration errors, like specifying non-numbers for parameters that need to be numbers.

In this case, a different exit code might be clearer. I changed it to `EX_SOFTWARE`; I'm not sure if that's correct but it seems more accurate than `EX_CONFIG` and you've used elsewhere in the code already. I also added an error message based on the error code returned from the loader. Now my situation gives this somewhat more helpful output:

```sh
% mpw MWC68K; echo $?
Unable to load command /Users/rschmidt/mpw/MetroWerks/Tools/MWC68K: Logical end-of-file reached during read operation
70
% mpw MWCPPC; echo $?
Unable to load command /Users/rschmidt/mpw/MetroWerks/Tools/MWCPPC: Logical end-of-file reached during read operation
70
%
```