### PR TITLE
Return error from FSMakeFSSpec if file not found

### DIFF
--- a/toolbox/os_highlevel.cpp
+++ b/toolbox/os_highlevel.cpp
@@ -106,8 +106,6 @@ namespace OS {
 	{
 		// FSMakeFSSpec(vRefNum: Integer; dirID: LongInt; fileName: Str255; VAR spec: FSSpec): OSErr;
 
-		// todo -- if the file does not exist (but the path is otherwise valid), create the spec but return fnfErr.
-
 		/*
 		 * See Chapter 2, File Manager / Using the File Manager, 2-35
 		 *
@@ -176,7 +174,9 @@ namespace OS {
 			// write the filename...
 			ToolBox::WritePString(spec + 6, leaf);
 
-			return 0;
+			struct stat st;
+			int rv = ::stat(sname.c_str(), &st);
+			if (rv < 0) return macos_error_from_errno();
 		}
 
 		else


### PR DESCRIPTION
This works for me to fix the problems with MWC68K/MWCPPC I reported in #56, and SC and MrC still work too. Does this fix look correct to you? I have not yet tested it extensively.