### PR TITLE
ci: remove macos-11; add macos-13; upgrade to checkout@v4 and upload-artifact@v4

### DIFF
--- a/.github/workflows/cmake-fat.yml
+++ b/.github/workflows/cmake-fat.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -32,7 +32,7 @@ jobs:
       run: make mpw
       
     - name: Archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mpw fat
         path: ${{runner.workspace}}/build/bin/mpw

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-12, macos-11]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -35,7 +35,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE
       
     - name: Archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mpw ${{ matrix.os }}
         path: ${{runner.workspace}}/build/bin/mpw

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-11]
+        os: [macos-12, macos-13]
 
     steps:
     - uses: actions/checkout@v4
@@ -39,4 +39,3 @@ jobs:
       with:
         name: mpw ${{ matrix.os }}
         path: ${{runner.workspace}}/build/bin/mpw
-      


### PR DESCRIPTION
CI improvements:

### upgrade to checkout@v4 and upload-artifact@v4

checkout@v3 and upload-artifact@v3 are deprecated and will be removed.

### remove macos-11; add macos-13 

macos-11 will be removed by the end of June; replace it with macos-13. macos-14 a.k.a. macos-latest is already covered by cmake-fat.yml.