### PR TITLE
CI action updates, runner updates, CMake 4 fixes

### DIFF
--- a/.github/workflows/cmake-fat.yml
+++ b/.github/workflows/cmake-fat.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -32,7 +32,7 @@ jobs:
       run: make mpw
       
     - name: Archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mpw fat
         path: ${{runner.workspace}}/build/bin/mpw

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-15]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -35,7 +35,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE
       
     - name: Archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mpw ${{ matrix.os }}
         path: ${{runner.workspace}}/build/bin/mpw

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-15]
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(mpw VERSION 0.8.3 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
CI and CMake improvements continuing from https://github.com/ksherlock/libsane/pull/2:

* Remove obsolete macOS 12 and 13 runners; add macOS 15 runner. Note this is now arm64 instead of x86_64.
* Upgrade checkout and upload-artifact actions to latest versions because the old ones are deprecated.
* Increase minimum CMake version to 3.5 to fix build failure with CMake 4.
* Update libsane submodule to get the same CMake 4 fix.