### PR TITLE
fix: the mplite_free() function does not validate wh... in mplite.c

### DIFF
--- a/mplite/mplite.c
+++ b/mplite/mplite.c
@@ -130,13 +130,19 @@ MPLITE_API void *mplite_malloc(mplite_t *handle, const int nBytes)
 
 MPLITE_API void mplite_free(mplite_t *handle, const void *pPrior)
 {
+    int iBlock;
+
     /* Check the parameters */
     if ((NULL == handle) || (NULL == pPrior)) {
         return;
     }
 
     mplite_enter(handle);
-    mplite_free_unsafe(handle, pPrior);
+    iBlock = (int)((uint8_t *) pPrior - handle->zPool) / handle->szAtom;
+    /* Guard against double-free: only free if the block is not already free */
+    if ((handle->aCtrl[iBlock] & MPLITE_CTRL_FREE) == 0) {
+        mplite_free_unsafe(handle, pPrior);
+    }
     mplite_leave(handle);
 }
 

--- a/tests/test_invariant_mplite.c
+++ b/tests/test_invariant_mplite.c
@@ -1,0 +1,94 @@
+#include <check.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mplite/mplite.h"
+
+START_TEST(test_double_free_no_overlapping_allocations)
+{
+    // Invariant: After any sequence of alloc/free operations, no two live
+    // allocations should ever overlap (share the same memory region)
+    
+    // Setup pool allocator
+    char pool_buffer[4096];
+    mplite_t pool;
+    int ret = mplite_init(&pool, pool_buffer, sizeof(pool_buffer), 8, NULL);
+    ck_assert_int_eq(ret, MPLITE_OK);
+    
+    // Test cases: allocation sizes to test
+    size_t alloc_sizes[] = {16, 32, 64};
+    int num_sizes = sizeof(alloc_sizes) / sizeof(alloc_sizes[0]);
+    
+    for (int i = 0; i < num_sizes; i++) {
+        size_t size = alloc_sizes[i];
+        
+        // Allocate first block
+        void *ptr1 = mplite_malloc(&pool, size);
+        ck_assert_ptr_nonnull(ptr1);
+        memset(ptr1, 0xAA, size);
+        
+        // Free it (first free - valid)
+        mplite_free(&pool, ptr1);
+        
+        // Double free (the vulnerability) - this corrupts free list
+        mplite_free(&pool, ptr1);
+        
+        // Now allocate two blocks - they should NOT overlap
+        void *ptr2 = mplite_malloc(&pool, size);
+        void *ptr3 = mplite_malloc(&pool, size);
+        
+        if (ptr2 != NULL && ptr3 != NULL) {
+            // Security invariant: two live allocations must not be the same
+            ck_assert_msg(ptr2 != ptr3,
+                "SECURITY VIOLATION: Two allocations returned same address "
+                "(overlapping memory) after double-free");
+            
+            // Write to both and verify no corruption
+            memset(ptr2, 0xBB, size);
+            memset(ptr3, 0xCC, size);
+            
+            unsigned char *p2 = (unsigned char *)ptr2;
+            unsigned char *p3 = (unsigned char *)ptr3;
+            
+            for (size_t j = 0; j < size; j++) {
+                ck_assert_msg(p2[j] == 0xBB,
+                    "SECURITY VIOLATION: ptr2 corrupted by write to ptr3");
+                ck_assert_msg(p3[j] == 0xCC,
+                    "SECURITY VIOLATION: ptr3 corrupted by write to ptr2");
+            }
+            
+            mplite_free(&pool, ptr2);
+            mplite_free(&pool, ptr3);
+        }
+    }
+}
+END_TEST
+
+Suite *security_suite(void)
+{
+    Suite *s;
+    TCase *tc_core;
+
+    s = suite_create("Security");
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_double_free_no_overlapping_allocations);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void)
+{
+    int number_failed;
+    Suite *s;
+    SRunner *sr;
+
+    s = security_suite();
+    sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Fix high severity security issue in `mplite/mplite.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-004 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-004` |
| **File** | `mplite/mplite.c:131` |
| **Assessment** | Confirmed exploitable |
| **Chain Complexity** | 2-step |

**Description**: The mplite_free() function does not validate whether the pointer has already been freed. Calling free twice on the same pointer corrupts the internal free-list metadata of the custom pool allocator, potentially causing the same memory region to be returned by two subsequent allocations. This creates overlapping allocations where writes to one corrupt another.

## Evidence

**Exploitation scenario**: An attacker provides crafted input to the CPU emulator that triggers an error path where cleanup code frees the same mplite-allocated pointer twice.

**Scanner confirmation**: multi_agent_ai rule `V-004` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `mplite/mplite.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```c
#include <check.h>
#include <stdlib.h>
#include <string.h>
#include "mplite/mplite.h"

START_TEST(test_double_free_no_overlapping_allocations)
{
    // Invariant: After any sequence of alloc/free operations, no two live
    // allocations should ever overlap (share the same memory region)
    
    // Setup pool allocator
    char pool_buffer[4096];
    mplite_t pool;
    int ret = mplite_init(&pool, pool_buffer, sizeof(pool_buffer), 8, NULL);
    ck_assert_int_eq(ret, MPLITE_OK);
    
    // Test cases: allocation sizes to test
    size_t alloc_sizes[] = {16, 32, 64};
    int num_sizes = sizeof(alloc_sizes) / sizeof(alloc_sizes[0]);
    
    for (int i = 0; i < num_sizes; i++) {
        size_t size = alloc_sizes[i];
        
        // Allocate first block
        void *ptr1 = mplite_malloc(&pool, size);
        ck_assert_ptr_nonnull(ptr1);
        memset(ptr1, 0xAA, size);
        
        // Free it (first free - valid)
        mplite_free(&pool, ptr1);
        
        // Double free (the vulnerability) - this corrupts free list
        mplite_free(&pool, ptr1);
        
        // Now allocate two blocks - they should NOT overlap
        void *ptr2 = mplite_malloc(&pool, size);
        void *ptr3 = mplite_malloc(&pool, size);
        
        if (ptr2 != NULL && ptr3 != NULL) {
            // Security invariant: two live allocations must not be the same
            ck_assert_msg(ptr2 != ptr3,
                "SECURITY VIOLATION: Two allocations returned same address "
                "(overlapping memory) after double-free");
            
            // Write to both and verify no corruption
            memset(ptr2, 0xBB, size);
            memset(ptr3, 0xCC, size);
            
            unsigned char *p2 = (unsigned char *)ptr2;
            unsigned char *p3 = (unsigned char *)ptr3;
            
            for (size_t j = 0; j < size; j++) {
                ck_assert_msg(p2[j] == 0xBB,
                    "SECURITY VIOLATION: ptr2 corrupted by write to ptr3");
                ck_assert_msg(p3[j] == 0xCC,
                    "SECURITY VIOLATION: ptr3 corrupted by write to ptr2");
            }
            
            mplite_free(&pool, ptr2);
            mplite_free(&pool, ptr3);
        }
    }
}
END_TEST

Suite *security_suite(void)
{
    Suite *s;
    TCase *tc_core;

    s = suite_create("Security");
    tc_core = tcase_create("Core");

    tcase_add_test(tc_core, test_double_free_no_overlapping_allocations);
    suite_add_tcase(s, tc_core);

    return s;
}

int main(void)
{
    int number_failed;
    Suite *s;
    SRunner *sr;

    s = security_suite();
    sr = srunner_create(s);

    srunner_run_all(sr, CK_NORMAL);
    number_failed = srunner_ntests_failed(sr);
    srunner_free(sr);

    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
}
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
